### PR TITLE
feat: broaden docker networks API filter to support Traefik Hub

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -14,7 +14,7 @@ var urlRegexes = []*regexp.Regexp{
 	genRegex(`^/v\d+\.\d+/containers/json\?limit=\d+$`),
 	genRegex(`^/v\d+\.\d+/containers/[0-9a-fA-F]+/json$`),
 	genRegex(`^/v\d+\.\d+/events\?filters=%7B%22type%22%3A%7B%22container%22%3Atrue%7D%7D$`),
-	genRegex(`^/v\d+\.\d+/networks\?filters=`),
+	genRegex(`^/v\d+\.\d+/networks$`),
 	genRegex(`^/v\d+\.\d+/services$`),
 	genRegex(`^/v\d+\.\d+/tasks\?filters=`),
 	genRegex(`^/v\d+\.\d+/version$`),


### PR DESCRIPTION
The Traefik Hub agent container requires access to the `networks` Docker Engine API endpoint to discover published ports for Docker and Docker Compose based containers.

The proposed change broadens the regular expression that limits access only to the filters query, while still being protected by the `GET` method filter.

Fixes #2 